### PR TITLE
Fixes bug where persisted value would be parsed twice causing a parse…

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function useStateAndPersistence(createMethods, initial, key, options) {
   const [value, setValue] = useState(() => {
     const persistedValue = get()
     return persistedValue
-      ? JSON.parse(persistedValue)
+      ? persistedValue
       : initial
   })
 


### PR DESCRIPTION
Fixes bug where the persisted value would be parsed twice causing a parse error. The stored value is parsed in both the `createStorageMethods` and `createCookieMethods` so parsing it in `useStateAndPersistence` caused the value to be parsed twice and threw an error.

I think everything is working as expected now! :) This is a super useful hook, and thanks for accepting my other pull request so quickly!