### PR TITLE
Fix bug with the initial value and expire date

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function createSessionStorageMethods(key) {
 
 function createCookieMethods(key, { days }) {
 	return {
-		set: (value, options={}) => {
+		set: (value, options = {}) => {
 			const expiration_days = options.days || days
 			let expiration = null
 
@@ -73,9 +73,9 @@ function useStateAndPersistence(createMethods, initial = null, key, options) {
 
 	return [
 		value,
-		(getNextValue, callback) => {
+		(getNextValue, callback, options) => {
 			const nextValue = typeof getNextValue === 'function' ? getNextValue(value) : getNextValue
-			set(nextValue)
+			set(nextValue, options)
 			setValue(nextValue)
 			if (callback) callback()
 		},

--- a/index.js
+++ b/index.js
@@ -25,16 +25,21 @@ function createSessionStorageMethods(key) {
 function createCookieMethods(key, { days }) {
 	return {
 		set: (value) => {
-			const stringified = JSON.stringify(value)
+			const new_value = value?.value || value
+			const expiration_days = value?.days || days
+			const stringified = JSON.stringify(new_value)
 			let expiration = null
+
 			if (days) {
 				const currentDate = new Date()
-				const expirationTime = currentDate.getTime() + days * 24 * 60 * 60 * 1000
+				const expirationTime = currentDate.getTime() + expiration_days * 24 * 60 * 60 * 1000
 				const expirationString = new Date(expirationTime).toUTCString()
+
 				expiration = `; expires=${expirationString}`
 			} else {
 				expiration = ''
 			}
+
 			document.cookie = `${key}=${stringified}${expiration}; path=/`
 		},
 
@@ -46,17 +51,18 @@ function createCookieMethods(key, { days }) {
 					return JSON.parse(parts[1])
 				}
 			}
-			return {}
+			return null
 		},
 	}
 }
 
-function useStateAndPersistence(createMethods, initial, key, options) {
+function useStateAndPersistence(createMethods, initial = null, key, options) {
 	const { get, set } = createMethods(key, options)
 
 	const [value, setValue] = useState(() => {
 		const persistedValue = get()
-		return persistedValue || initial
+
+		return persistedValue ? persistedValue : initial !== null ? initial : {}
 	})
 
 	return [

--- a/index.js
+++ b/index.js
@@ -24,13 +24,11 @@ function createSessionStorageMethods(key) {
 
 function createCookieMethods(key, { days }) {
 	return {
-		set: (value) => {
-			const new_value = value?.value || value
-			const expiration_days = value?.days || days
-			const stringified = JSON.stringify(new_value)
+		set: (value, options={}) => {
+			const expiration_days = options.days || days
 			let expiration = null
 
-			if (days) {
+			if (expiration_days) {
 				const currentDate = new Date()
 				const expirationTime = currentDate.getTime() + expiration_days * 24 * 60 * 60 * 1000
 				const expirationString = new Date(expirationTime).toUTCString()
@@ -40,7 +38,7 @@ function createCookieMethods(key, { days }) {
 				expiration = ''
 			}
 
-			document.cookie = `${key}=${stringified}${expiration}; path=/`
+			document.cookie = `${key}=${JSON.stringify(value)}${expiration}; path=/`
 		},
 
 		get: () => {
@@ -62,7 +60,15 @@ function useStateAndPersistence(createMethods, initial = null, key, options) {
 	const [value, setValue] = useState(() => {
 		const persistedValue = get()
 
-		return persistedValue ? persistedValue : initial !== null ? initial : {}
+		if (persistedValue) {
+			return persistedValue
+		}
+
+		if (initial !== null) {
+			return initial
+		}
+
+		return {}
 	})
 
 	return [


### PR DESCRIPTION
- Fix bug with the initial state that is always returning an empty object `{}`
- Improves on the `set()` function for the cookies
  - The function params now can be an object with the keys `value` and `days` to set an custom expiration day to the cookie
  - The params can also be a number / string / or other variable type and the expiration day will be the initial days defined
  
 Pending of code review to update read me 